### PR TITLE
Fix issue throw 500 when disable supplier

### DIFF
--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -308,8 +308,8 @@ export class ProductService {
 
     if (productFilter.supplierId) {
       queryBuilder.leftJoinAndSelect('product.masterProduct', 'masterProduct4')
-      queryBuilder.leftJoinAndSelect('masterProduct4.supplier', 'supplier1')
-      queryBuilder.andWhere("supplier1.id = :supplierId", { supplierId: productFilter.supplierId })
+      queryBuilder.leftJoinAndSelect('masterProduct4.suppliers', 'suppliers1')
+      queryBuilder.andWhere("suppliers1.id = :supplierId", { supplierId: productFilter.supplierId })
     }
 
     if (productFilter.rackId) {


### PR DESCRIPTION
## Card
https://trello.com/c/krME5oXw

## Root cause:

The error is occurring because you're trying to join masterProduct4.supplier but the relation should be masterProduct4.suppliers (plural). This is a common issue when the relation name doesn't match exactly.

## Solution:

### The changes:

- masterProduct4.supplier to masterProduct4.suppliers

- supplier1 to suppliers1 (for consistency)

- supplier1.id to suppliers1.id in the where clause

This assumes you have a many-to-many relationship between MasterProduct and Supplier entities


